### PR TITLE
Add initial propositional calculus abstract syntax tree classes

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -1,0 +1,26 @@
+package go_sat_solver
+
+type Expr interface {
+	Children() []Expr
+}
+
+type And struct {
+	clauses []Expr
+}
+
+type Or struct {
+	clauses []Expr
+}
+
+type Not struct {
+	child [1]Expr
+}
+
+type Symbol struct {
+	name string
+}
+
+func (e And) Children() []Expr { return e.clauses }
+func (e Or) Children() []Expr { return e.clauses }
+func (e Not) Children() []Expr { return e.child[:] }
+func (e Symbol) Children() []Expr { return nil }

--- a/ast_test.go
+++ b/ast_test.go
@@ -1,0 +1,22 @@
+package go_sat_solver
+
+import "testing"
+
+
+func TestPrint(t *testing.T) {
+	cases := []struct {
+		expr Expr
+		want int
+	}{
+		{And{[]Expr{Symbol{"x1"}, Symbol{"x2"}}}, 2},
+		{Or{[]Expr{Symbol{"x1"}, Symbol{"x2"}, Symbol{"x3"}}}, 3},
+		{Not{[1]Expr{Symbol{"x1"}}}, 1},
+		{Symbol{"x1"}, 0},
+	}
+	for _, c := range cases {
+		got := len(c.expr.Children())
+		if got != c.want {
+			t.Errorf("Children(%#v).len == %v, want %v", c.expr, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
This commit adds base structs for (non CNF) sat expressions 